### PR TITLE
Fix ClickGUI keybind

### DIFF
--- a/src/main/java/me/stormcph/lumina/Lumina.java
+++ b/src/main/java/me/stormcph/lumina/Lumina.java
@@ -59,7 +59,7 @@ public class Lumina implements ModInitializer {
                 if (event.getKey() == module.getKey()) module.toggle();
             }
 
-            if (openClickGuiKey.wasPressed()) {
+            if (event.matches(openClickGuiKey)) {
                 switch (ClickguiModule.clickguiMode.getMode()) {
                     case "New" -> {
                         mc.setScreen(ClickGui.instance);

--- a/src/main/java/me/stormcph/lumina/event/impl/KeyEvent.java
+++ b/src/main/java/me/stormcph/lumina/event/impl/KeyEvent.java
@@ -1,6 +1,8 @@
 package me.stormcph.lumina.event.impl;
 
 import me.stormcph.lumina.event.Event;
+import net.minecraft.client.option.KeyBinding;
+import org.lwjgl.glfw.GLFW;
 
 public class KeyEvent extends Event {
 
@@ -22,5 +24,9 @@ public class KeyEvent extends Event {
 
     public int getAction() {
         return action;
+    }
+
+    public boolean matches(KeyBinding keyBinding) {
+        return keyBinding.matchesKey(this.key, GLFW.GLFW_KEY_UNKNOWN);
     }
 }


### PR DESCRIPTION
Before, when pressing the ClickGUI keybind, the ClickGUI would open on the next key press. This is because the `KeyboardMixin` associated with the key press event targets the head of the `onKey` method, whilst the method used to check the key pressed was `KeyBinding#wasPressed()`. Since `wasPressed` only updates when `KeyBinding#onKeyPressed()` is called at the end of `onKey`, the event fired before it updated.

It would have been possible to fix this by moving the mixin injection point to the end of `onKey`, but since the event is cancellable and cancelling at the end of the `onKey` method would have still registered the key press normally, I have opted to create the `matches` helper method instead, which should be used in place of `wasPressed` in all future usages of `KeyEvent`.

TL;DR: ClickGUI opens immediately instead of on next key press.